### PR TITLE
Add support for list and single element inference input

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -15,7 +15,7 @@ from skl2onnx.common.data_types import FloatTensorType
 import numpy as np
 import logging
 import secrets
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union, List
 from web3.exceptions import ContractLogicError
 from web3.datastructures import AttributeDict
 import src.utils
@@ -254,7 +254,7 @@ class Client:
             logging.error(f"Unexpected error during upload: {str(e)}")
             raise OpenGradientError(f"Unexpected error during upload: {str(e)}")
     
-    def infer(self, model_id: str, inference_mode: InferenceMode, model_input: Dict[str, np.ndarray]) -> Tuple[str, Dict[str, np.ndarray]]:
+    def infer(self, model_id: str, inference_mode: InferenceMode, model_input: Dict[str, Union[str, int, float, List, np.ndarray]]) -> Tuple[str, Dict[str, np.ndarray]]:
         if not self.user:
             raise ValueError("User not authenticated")
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,6 +48,16 @@ def convert_to_model_input(inputs: Dict[str, np.ndarray]) -> Tuple[List[Tuple[st
     number_tensors = []
     string_tensors = []
     for tensor_name, tensor_data in inputs.items():
+        # Convert to NP array if list or single object
+        if isinstance(tensor_data, list):
+            logging.debug(f"\tConverting {tensor_data} to np array")
+            tensor_data = np.array(tensor_data)
+
+        if isinstance(tensor_data, (str, int, float)):
+            logging.debug(f"\tConverting single entry {tensor_data} to a list")
+            tensor_data = np.array([tensor_data])
+
+        # Parse into number and string tensors
         if issubclass(tensor_data.dtype.type, np.floating):
             input = (tensor_name, [convert_to_fixed_point(i) for i in tensor_data])
             logging.debug("\tFloating tensor input: %s", input)
@@ -92,6 +102,8 @@ def convert_to_model_output(event_data: AttributeDict) -> Dict[str, np.ndarray]:
                     else:
                         logging.warning(f"Unexpected number type: {type(v)}")
                 output_dict[name] = np.array(values)
+            else:
+                logging.warning(f"Unexpected tensor type: {type(tensor)}")
 
         # Parse strings
         for tensor in output.get('strings', []):
@@ -100,6 +112,8 @@ def convert_to_model_output(event_data: AttributeDict) -> Dict[str, np.ndarray]:
                 name = tensor.get('name')
                 values = tensor.get('values', [])
                 output_dict[name] = values
+            else:
+                    logging.warning(f"Unexpected tensor type: {type(tensor)}")
     else:
         logging.warning(f"Unexpected output type: {type(output)}")
 


### PR DESCRIPTION
Can now inference with inputs such as:
model_input = {}
model_input["num_input1"] = [1.0, 2.0, 3.0]
model_input["num_input2"] = 10
model_input["str_input1"] = np.array(["hello", "ONNX"])
model_input["str_input2"] = " world"