### PR TITLE
Add output type for text generation functions

### DIFF
--- a/src/opengradient/cli.py
+++ b/src/opengradient/cli.py
@@ -384,7 +384,7 @@ def completion(ctx, model_cid: str, inference_mode: str, prompt: str, max_tokens
             temperature=temperature,
         )
 
-        print_llm_completion_result(model_cid, completion_output.transaction_hash, completion_output.answer)
+        print_llm_completion_result(model_cid, completion_output.transaction_hash, completion_output.completion_output)
     except Exception as e:
         click.echo(f"Error running LLM completion: {str(e)}")
 
@@ -528,7 +528,7 @@ def chat(
             tool_choice=tool_choice,
         )
 
-        print_llm_chat_result(model_cid, completion_output.transaction_hash, completion_output.finish_reason, completion_output.message)
+        print_llm_chat_result(model_cid, completion_output.transaction_hash, completion_output.finish_reason, completion_output.chat_output)
     except Exception as e:
         click.echo(f"Error running LLM chat inference: {str(e)}")
 

--- a/src/opengradient/client.py
+++ b/src/opengradient/client.py
@@ -350,7 +350,7 @@ class Client:
         stop_sequence: Optional[List[str]] = None,
         temperature: float = 0.0,
         max_retries: Optional[int] = None,
-    ) -> Tuple[str, str]:
+    ) -> TextGenerationOutput:
         """
         Perform inference on an LLM model using completions.
 
@@ -363,7 +363,9 @@ class Client:
             temperature (float): Temperature for LLM inference, between 0 and 1. Default is 0.0.
 
         Returns:
-            Tuple[str, str]: The transaction hash and the LLM completion output.
+            TextGenerationOutput: Generated text results including:
+                - Transaction hash
+                - String of completion output
 
         Raises:
             OpenGradientError: If the inference fails.
@@ -421,7 +423,7 @@ class Client:
             
             return TextGenerationOutput(
                 transaction_hash=tx_hash.hex(),
-                answer=llm_answer
+                completion_output=llm_answer
             )
 
         return run_with_retry(execute_transaction, max_retries)
@@ -437,7 +439,7 @@ class Client:
         tools: Optional[List[Dict]] = [],
         tool_choice: Optional[str] = None,
         max_retries: Optional[int] = None,
-    ) -> Tuple[str, str]:
+    ) -> TextGenerationOutput:
         """
         Perform inference on an LLM model using chat.
 
@@ -489,7 +491,10 @@ class Client:
             tool_choice (str, optional): Sets a specific tool to choose. Default value is "auto".
 
         Returns:
-            Tuple[str, str, dict]: The transaction hash, finish reason, and a dictionary struct of LLM chat messages.
+            TextGenerationOutput: Generated text results including:
+                - Transaction hash
+                - Finish reason (tool_call, stop, etc.)
+                - Dictionary of chat message output (role, content, tool_call, etc.)
 
         Raises:
             OpenGradientError: If the inference fails.
@@ -577,7 +582,7 @@ class Client:
             return TextGenerationOutput(
                 transaction_hash=tx_hash.hex(),
                 finish_reason=llm_result["finish_reason"],
-                message=message,
+                chat_output=message,
             )
 
         return run_with_retry(execute_transaction, max_retries)

--- a/src/opengradient/llm/og_langchain.py
+++ b/src/opengradient/llm/og_langchain.py
@@ -100,7 +100,7 @@ class OpenGradientChatModel(BaseChatModel):
             inference_mode=LlmInferenceMode.VANILLA,
         )
         finish_reason = chat_output.finish_reason
-        chat_response = chat_output.message
+        chat_response = chat_output.chat_output
 
         if "tool_calls" in chat_response and chat_response["tool_calls"]:
             tool_calls = []

--- a/src/opengradient/llm/og_openai.py
+++ b/src/opengradient/llm/og_openai.py
@@ -36,7 +36,7 @@ class OGCompletions(object):
             inference_mode=og.LlmInferenceMode.VANILLA,
         )
         finish_reason = chat_output.finish_reason
-        chat_completion = chat_output.message
+        chat_completion = chat_output.chat_output
 
         choice = {
             "index": 0,  # Add missing index field

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -101,12 +101,19 @@ class ModelOutput:
 @dataclass
 class TextGenerationOutput:
     """
-    Text generation output struct
+    Output structure for text generation requests.
     """
     transaction_hash: str
+    """Blockchain hash for the transaction."""
+
     finish_reason: str | None = ""
-    message: Dict[str, Union[str, list]] | None = DefaultDict
-    answer: str | None = ""
+    """Reason for completion (e.g., 'tool_call', 'stop', 'error'). Empty string if not applicable."""
+    
+    chat_output: Dict | None = DefaultDict
+    """Dictionary of chat response containing role, message content, tool call parameters, etc.. Empty dict if not applicable."""
+
+    completion_output: str | None = ""
+    """Raw text output from completion-style generation. Empty string if not applicable."""
 
 
 @dataclass


### PR DESCRIPTION
These previously just returned raw tuples with no structure. This gives chat / completion output some structure.

I tested this simply using the Makefile -- we might need farther testing (e.g. how will this effect other tools like dappy?).