### PR TITLE
docs: fix network default documentation (devnet not mainnet)

### DIFF
--- a/docs/opengradient/index.md
+++ b/docs/opengradient/index.md
@@ -130,8 +130,8 @@ Initialize the OpenGradient SDK with authentication and network settings.
 * **`email`**: User's email address for authentication
 * **`password`**: User's password for authentication
 * **`private_key`**: Ethereum private key for blockchain transactions
-* **`rpc_url`**: Optional RPC URL for the blockchain network, defaults to mainnet
-* **`api_url`**: Optional API URL for the OpenGradient API, defaults to mainnet
+* **`rpc_url`**: Optional RPC URL for the blockchain network, defaults to devnet
+* **`api_url`**: Optional API URL for the OpenGradient API, defaults to devnet
 * **`contract_address`**: Optional inference contract address
   
 


### PR DESCRIPTION
## Description
This PR fixes the documentation in \docs/opengradient/index.md\ that incorrectly states the network defaults to mainnet.

## Changes
- Changed \pc_url\ documentation from 'defaults to mainnet' to 'defaults to devnet'
- Changed \pi_url\ documentation from 'defaults to mainnet' to 'defaults to devnet'

## Related
- Related to Issue #140 (documentation audit findings)
- Complements PR #141 which fixed the source code docstrings

## Context
The actual default values in the code are:
- \pc_url\: \https://ogevmdevnet.opengradient.ai\ (devnet)
- \pi_url\: \https://sdk-devnet.opengradient.ai\ (devnet)

The documentation should accurately reflect these defaults to avoid confusion for developers.