### PR TITLE
docs: improve LLM and TEE_LLM enum documentation

### DIFF
--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -413,7 +413,30 @@ class Abi:
 
 
 class LLM(str, Enum):
-    """Enum for available LLM models"""
+    """
+    Enum for available LLM models in OpenGradient.
+
+    These models can be used with llm_chat() and llm_completion() methods.
+    You can use either the enum value or the string identifier directly.
+
+    Usage:
+        # Using enum (recommended)
+        result = client.llm_chat(model_cid=og.LLM.GPT_4O, messages=[...])
+
+        # Using string directly
+        result = client.llm_chat(model_cid="openai/gpt-4o", messages=[...])
+
+    Model Identifier Format:
+        Models use the format: "{provider}/{model-name}"
+        - OpenAI: "openai/gpt-4o", "openai/gpt-4.1-2025-04-14"
+        - Anthropic: "anthropic/claude-3.7-sonnet", "anthropic/claude-4.0-sonnet"
+        - Google: "google/gemini-2.5-flash", "google/gemini-2.5-pro"
+        - xAI: "x-ai/grok-3-beta", "x-ai/grok-4.1-fast"
+
+    Note:
+        TEE_LLM enum contains the same models but is specifically for
+        Trusted Execution Environment (TEE) verified inference.
+    """
 
     # # Existing open-source OG hosted models
     # META_LLAMA_3_8B_INSTRUCT = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -449,7 +472,25 @@ class LLM(str, Enum):
 
 
 class TEE_LLM(str, Enum):
-    """Enum for LLM models available for TEE execution"""
+    """
+    Enum for LLM models available for TEE (Trusted Execution Environment) execution.
+
+    TEE mode provides cryptographic verification that inference was performed
+    correctly in a secure enclave. Use this for applications requiring
+    auditability and tamper-proof AI inference.
+
+    Usage:
+        # TEE-verified inference
+        result = client.llm_chat(
+            model_cid=og.TEE_LLM.GPT_4O,
+            messages=[{"role": "user", "content": "Hello"}],
+            inference_mode=og.LlmInferenceMode.TEE
+        )
+
+    Note:
+        The models in TEE_LLM are the same as LLM, but this enum explicitly
+        indicates support for TEE execution.
+    """
 
     # Existing (Currently turned off)
     # META_LLAMA_3_1_70B_INSTRUCT = "meta-llama/Llama-3.1-70B-Instruct"


### PR DESCRIPTION
Improves documentation for LLM and TEE_LLM enums. Adds usage examples and explains model identifier format. Related to Issue #140.