### PR TITLE
Fix regression: CLI prints private key to stdout

### DIFF
--- a/src/opengradient/cli.py
+++ b/src/opengradient/cli.py
@@ -828,7 +828,7 @@ def create_account_impl() -> EthAccount:
     click.echo("=" * 50)
     click.echo("\nYour OpenGradient account has been successfully created and funded.")
     click.secho(f"Address: {eth_account.address}", fg="green")
-    click.secho(f"Private Key: {eth_account.private_key}", fg="green")
+    click.secho("Private key generated. Store it securely; it will not be shown.", fg="yellow")
     click.secho("\nPlease save this information for your records.\n", fg="cyan")
 
     return eth_account


### PR DESCRIPTION
This pull request fixes a security regression where the CLI prints the private key to stdout
during account creation.

The private key was previously removed from CLI output, but was reintroduced in the current
main branch. Printing private keys to stdout can lead to accidental disclosure via terminal
logs, CI pipelines, or screen sharing.

This change removes the private key from CLI output and replaces it with a safe informational
message, restoring the intended secure behavior.
