### PR TITLE
Remove direct external LLM provider functionality

### DIFF
--- a/docs/CLAUDE_SDK_USERS.md
+++ b/docs/CLAUDE_SDK_USERS.md
@@ -21,15 +21,14 @@ import os
 # Initialize client
 client = og.new_client(
     private_key=os.environ["OG_PRIVATE_KEY"],  # Required: Ethereum private key
-    openai_api_key=os.environ.get("OPENAI_API_KEY"),  # Optional: for OpenAI models
-    anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY"),  # Optional: for Claude
 )
 
-# LLM Chat
+# LLM Chat (TEE mode with x402 payments)
 result = client.llm_chat(
-    model_cid="gpt-4o",  # or og.LLM.CLAUDE_3_5_HAIKU
+    model_cid=og.TEE_LLM.CLAUDE_3_5_HAIKU,  # TEE-verified model
     messages=[{"role": "user", "content": "Hello!"}],
     max_tokens=100,
+    inference_mode=og.LlmInferenceMode.TEE,
 )
 print(result.chat_output["content"])
 ```
@@ -44,9 +43,6 @@ client = og.new_client(
     private_key="0x...",           # Required: Ethereum private key
     email=None,                    # Optional: Model Hub auth
     password=None,                 # Optional: Model Hub auth
-    openai_api_key=None,           # Optional: OpenAI access
-    anthropic_api_key=None,        # Optional: Anthropic access
-    google_api_key=None,           # Optional: Google access
 )
 
 # Option 2: Global initialization
@@ -126,12 +122,17 @@ og.TEE_LLM.GROK_3_BETA
 og.TEE_LLM.GROK_3_MINI_BETA
 ```
 
-### External Providers (by string)
+### Using Models with TEE Mode
+
+All TEE models are accessed through the OpenGradient infrastructure with x402 payments:
 
 ```python
-"gpt-4o", "gpt-4-turbo"        # OpenAI
-"claude-3-sonnet"              # Anthropic
-"gemini-2-5-pro"               # Google
+# Use TEE mode for cryptographic proof of execution
+result = client.llm_chat(
+    model_cid=og.TEE_LLM.GPT_4O,  # or og.TEE_LLM.CLAUDE_3_5_HAIKU, etc.
+    messages=[{"role": "user", "content": "Hello"}],
+    inference_mode=og.LlmInferenceMode.TEE,
+)
 ```
 
 ## Common Patterns
@@ -293,9 +294,6 @@ except OpenGradientError as e:
 
 ```bash
 OG_PRIVATE_KEY=0x...          # Required: Ethereum private key
-OPENAI_API_KEY=sk-...         # Optional: for OpenAI models
-ANTHROPIC_API_KEY=sk-ant-...  # Optional: for Anthropic models
-GOOGLE_API_KEY=AIza...        # Optional: for Google models
 ```
 
 ## Resources

--- a/src/opengradient/defaults.py
+++ b/src/opengradient/defaults.py
@@ -8,7 +8,6 @@ DEFAULT_SCHEDULER_ADDRESS = "0x7179724De4e7FF9271FA40C0337c7f90C0508eF6"
 DEFAULT_BLOCKCHAIN_EXPLORER = "https://explorer.opengradient.ai/tx/"
 DEFAULT_IMAGE_GEN_HOST = "imagegen.opengradient.ai"
 DEFAULT_IMAGE_GEN_PORT = 5125
-DEFAULT_LLM_SERVER_URL = "https://llm.opengradient.ai"
 DEFAULT_OPENGRADIENT_LLM_SERVER_URL = "https://llmogevm.opengradient.ai"
 DEFAULT_OPENGRADIENT_LLM_STREAMING_SERVER_URL = "https://llmogevm.opengradient.ai"
 DEFAULT_NETWORK_FILTER = "og-evm"


### PR DESCRIPTION
Remove the ability to send requests directly to external LLM providers (OpenAI, Anthropic, Google) using API keys. All LLM inference now goes through OpenGradient infrastructure:

- VANILLA mode: on-chain inference with transaction settlement
- TEE mode: verified execution with x402 payments

Changes:
- Remove openai_api_key, anthropic_api_key, google_api_key params
- Remove set_api_key/remove_api_key CLI commands
- Remove _external_api_keys and related helper methods
- Rename _external_llm_* functions to _tee_llm_*
- Remove API key code paths from TEE functions
- Update CLI help text and documentation
- Remove DEFAULT_LLM_SERVER_URL

The x402/TEE functionality remains intact for verified AI execution.