### PR TITLE
fix: use None instead of mutable default for tools parameter

### DIFF
--- a/src/opengradient/client/llm.py
+++ b/src/opengradient/client/llm.py
@@ -178,7 +178,7 @@ class LLM:
         max_tokens: int = 100,
         stop_sequence: Optional[List[str]] = None,
         temperature: float = 0.0,
-        tools: Optional[List[Dict]] = [],
+        tools: Optional[List[Dict]] = None,
         tool_choice: Optional[str] = None,
         x402_settlement_mode: Optional[x402SettlementMode] = x402SettlementMode.SETTLE_BATCH,
         stream: bool = False,


### PR DESCRIPTION
## Summary

The `chat()` method in `src/opengradient/client/llm.py` used a mutable default argument:

```python
tools: Optional[List[Dict]] = []
```

This is a known Python anti-pattern that can cause shared state across function calls, leading to subtle and hard-to-debug issues.

## Fix

Changed to the safe pattern:

```python
tools: Optional[List[Dict]] = None
```

The existing code already handles `None` correctly since it uses `if tools:` which evaluates to `False` for both `[]` and `None`.

## Related

Fixes item #5 from issue #157.