### PR TITLE
fix: broken community URL in README Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,4 +341,4 @@ Browse and discover AI models on the [OpenGradient Model Hub](https://hub.opengr
 
 - Execute `opengradient --help` for CLI command reference
 - Visit our [documentation](https://docs.opengradient.ai/) for detailed guides
-- Join our [community](https://opengradient.ai/) for support and discussions
+- Join our [community](https://discord.gg/axammqTRDz) for support and discussions


### PR DESCRIPTION
The community link in the Support section pointed to https://.opengradient.ai/ which is an invalid URL due to a leading dot after the protocol scheme. Updated to the correct OpenGradient Discord community link.