### PR TITLE
fix: replace print() with logger and strengthen error handling

### DIFF
--- a/src/opengradient/client/alpha.py
+++ b/src/opengradient/client/alpha.py
@@ -7,6 +7,7 @@ including on-chain ONNX model inference, workflow management, and ML model execu
 
 import base64
 import json
+import logging
 import urllib.parse
 from typing import Dict, List, Optional, Union
 
@@ -20,6 +21,8 @@ from web3.logs import DISCARD
 from ..types import HistoricalInputQuery, InferenceMode, InferenceResult, ModelOutput, SchedulerParams
 from ._conversions import convert_array_to_model_output, convert_to_model_input, convert_to_model_output  # type: ignore[attr-defined]
 from ._utils import get_abi, get_bin, run_with_retry
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_RPC_URL = "https://ogevmdevnet.opengradient.ai"
 DEFAULT_API_URL = "https://sdk-devnet.opengradient.ai"
@@ -282,7 +285,8 @@ class Alpha:
                  will be automatically executed according to the specified schedule.
 
         Raises:
-            Exception: If transaction fails or gas estimation fails
+            RuntimeError: If the deployment transaction fails.
+                Gas estimation failure does not raise; a fallback gas limit is used instead.
         """
         # Get contract ABI and bytecode
         abi = get_abi("PriceHistoryInference.abi")
@@ -298,9 +302,8 @@ class Alpha:
                 estimated_gas = contract.constructor(*constructor_args).estimate_gas({"from": self._wallet_account.address})
                 gas_limit = int(estimated_gas * 1.2)
             except Exception as e:
-                print(f"Gas estimation failed: {str(e)}")
                 gas_limit = 5000000  # Conservative fallback
-                print(f"Using fallback gas limit: {gas_limit}")
+                logger.warning("Gas estimation failed: %s; using fallback gas limit %d", e, gas_limit)
 
             transaction = contract.constructor(*constructor_args).build_transaction(
                 {
@@ -318,7 +321,7 @@ class Alpha:
             tx_receipt = self._blockchain.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
 
             if tx_receipt["status"] == 0:
-                raise Exception(f"Contract deployment failed, transaction hash: {tx_hash.hex()}")
+                raise RuntimeError(f"Contract deployment failed, transaction hash: {tx_hash.hex()}")
 
             return tx_receipt.contractAddress
 
@@ -340,9 +343,9 @@ class Alpha:
                 - duration_hours: How long to run in hours
                 - end_time: Unix timestamp when scheduling should end
 
-        Raises:
-            Exception: If registration with scheduler fails. The workflow contract will
-                      still be deployed and can be executed manually.
+        Note:
+            Scheduler registration failures are logged as warnings and do not raise.
+            The workflow contract is already deployed and can be executed manually.
         """
         scheduler_abi = get_abi("WorkflowScheduler.abi")
 
@@ -368,8 +371,7 @@ class Alpha:
             scheduler_tx_hash = self._blockchain.eth.send_raw_transaction(signed_scheduler_tx.raw_transaction)
             self._blockchain.eth.wait_for_transaction_receipt(scheduler_tx_hash, timeout=REGULAR_TX_TIMEOUT)
         except Exception as e:
-            print(f"Error registering contract with scheduler: {str(e)}")
-            print("  The workflow contract is still deployed and can be executed manually.")
+            logger.warning("Error registering contract with scheduler: %s. The workflow contract is still deployed and can be executed manually.", e)
 
     def read_workflow_result(self, contract_address: str) -> ModelOutput:
         """

--- a/src/opengradient/client/llm.py
+++ b/src/opengradient/client/llm.py
@@ -365,8 +365,8 @@ class LLM:
             result = json.loads(raw_body.decode())
 
             choices = result.get("choices")
-            if not choices:
-                raise RuntimeError(f"Invalid response: 'choices' missing or empty in {result}")
+            if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+                raise RuntimeError(f"Invalid response: 'choices' missing or empty or malformed in {result}")
 
             message = choices[0].get("message", {})
             content = message.get("content")
@@ -498,6 +498,7 @@ class LLM:
                 try:
                     data = json.loads(data_str)
                 except json.JSONDecodeError:
+                    logger.warning("Skipping malformed SSE JSON: %r", data_str)
                     continue
 
                 chunk = StreamChunk.from_sse_data(data)

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -2,12 +2,15 @@
 OpenGradient Specific Types
 """
 
+import logging
 import time
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import AsyncIterator, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class x402SettlementMode(str, Enum):
@@ -349,7 +352,7 @@ class TextGenerationStream:
                 data = json.loads(data_str)
                 return StreamChunk.from_sse_data(data)
             except json.JSONDecodeError:
-                # Skip malformed chunks
+                logger.warning("Skipping malformed SSE JSON: %r", data_str)
                 continue
 
     async def __anext__(self) -> StreamChunk:
@@ -380,6 +383,7 @@ class TextGenerationStream:
                 data = json.loads(data_str)
                 return StreamChunk.from_sse_data(data)
             except json.JSONDecodeError:
+                logger.warning("Skipping malformed SSE JSON: %r", data_str)
                 continue
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,12 +1,15 @@
 import json
-from unittest.mock import MagicMock, mock_open, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 
+from opengradient.client.alpha import Alpha
 from opengradient.client.llm import LLM
 from opengradient.client.model_hub import ModelHub
 from opengradient.types import (
     StreamChunk,
+    TextGenerationStream,
     x402SettlementMode,
 )
 
@@ -190,3 +193,157 @@ class TestX402SettlementMode:
         assert x402SettlementMode.PRIVATE == "private"
         assert x402SettlementMode.BATCH_HASHED == "batch"
         assert x402SettlementMode.INDIVIDUAL_FULL == "individual"
+
+
+# --- Fix #4: choices[] guard ---
+
+
+class TestChoicesGuard:
+    """_chat_request must raise RuntimeError for any malformed choices value."""
+
+    @pytest.mark.asyncio
+    async def test_choices_empty_list_raises(self, mock_tee_registry):
+        """choices = [] → RuntimeError."""
+        llm = LLM(private_key="0x" + "a" * 64)
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.aread = AsyncMock(return_value=json.dumps({"choices": []}).encode())
+
+        mock_tee = MagicMock()
+        mock_tee.http_client.post = AsyncMock(return_value=mock_response)
+        mock_tee.metadata.return_value = {"tee_id": None, "tee_endpoint": None, "tee_payment_address": None}
+        llm._tee.get = MagicMock(return_value=mock_tee)
+        llm._tee.ensure_refresh_loop = MagicMock()
+
+        from opengradient.types import TEE_LLM
+        with pytest.raises(RuntimeError, match="choices"):
+            await llm.chat(model=TEE_LLM.CLAUDE_HAIKU_4_5, messages=[{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_choices_contains_none_raises(self, mock_tee_registry):
+        """choices = [None] passes the old 'not choices' guard but must now raise RuntimeError."""
+        llm = LLM(private_key="0x" + "a" * 64)
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.aread = AsyncMock(return_value=json.dumps({"choices": [None]}).encode())
+
+        mock_tee = MagicMock()
+        mock_tee.http_client.post = AsyncMock(return_value=mock_response)
+        mock_tee.metadata.return_value = {"tee_id": None, "tee_endpoint": None, "tee_payment_address": None}
+        llm._tee.get = MagicMock(return_value=mock_tee)
+        llm._tee.ensure_refresh_loop = MagicMock()
+
+        from opengradient.types import TEE_LLM
+        with pytest.raises(RuntimeError, match="choices"):
+            await llm.chat(model=TEE_LLM.CLAUDE_HAIKU_4_5, messages=[{"role": "user", "content": "hi"}])
+
+
+# --- Fix #6: SSE JSON logging ---
+
+
+class TestSSEJsonLogging:
+    """Malformed SSE JSON must emit a warning log, not silently disappear."""
+
+    def test_malformed_sse_logs_warning_in_sync_stream(self):
+        """TextGenerationStream.__next__ logs a warning for broken JSON."""
+        lines = iter(["data: { broken json \n", "data: [DONE]\n"])
+        stream = TextGenerationStream(_iterator=lines, _is_async=False)
+
+        with patch("opengradient.types.logger") as mock_logger:
+            try:
+                next(stream)
+            except StopIteration:
+                pass
+            mock_logger.warning.assert_called_once()
+            assert "Skipping malformed SSE JSON" in mock_logger.warning.call_args[0][0]
+
+    def test_valid_sse_does_not_log_warning(self):
+        """Well-formed SSE chunks must not trigger any warning."""
+        valid_data = json.dumps({
+            "model": "test",
+            "choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": None}],
+        })
+        lines = iter([f"data: {valid_data}\n", "data: [DONE]\n"])
+        stream = TextGenerationStream(_iterator=lines, _is_async=False)
+
+        with patch("opengradient.types.logger") as mock_logger:
+            chunk = next(stream)
+            mock_logger.warning.assert_not_called()
+            assert chunk.choices[0].delta.content == "hi"
+
+
+# --- Fix #13 & #14: Alpha exception type and logging ---
+
+
+class TestAlphaErrorHandling:
+    """Alpha.new_workflow raises RuntimeError (not bare Exception) on deployment failure,
+    and uses logger instead of print() for non-fatal warnings."""
+
+    @pytest.fixture
+    def alpha(self):
+        with patch("opengradient.client.alpha.Web3") as mock_web3_cls:
+            mock_w3 = MagicMock()
+            mock_web3_cls.return_value = mock_w3
+            mock_web3_cls.HTTPProvider.return_value = MagicMock()
+            mock_web3_cls.to_checksum_address.side_effect = lambda x: x
+            mock_w3.eth.account.from_key.return_value = MagicMock(address="0xDEAD")
+            mock_w3.eth.get_transaction_count.return_value = 1
+            mock_w3.eth.gas_price = 1000000000
+            mock_w3.eth.chain_id = 1
+            yield Alpha(private_key="0x" + "a" * 64)
+
+    def test_deployment_failure_raises_runtime_error(self, alpha):
+        """Status=0 receipt must raise RuntimeError, not bare Exception."""
+        mock_contract = MagicMock()
+        mock_contract.constructor.return_value.estimate_gas.return_value = 100000
+        mock_contract.constructor.return_value.build_transaction.return_value = {}
+
+        fake_receipt = {"status": 0, "transactionHash": b"\xde\xad"}
+        alpha._blockchain.eth.contract.return_value = mock_contract
+        alpha._blockchain.eth.send_raw_transaction.return_value = b"\xde\xad"
+        alpha._blockchain.eth.wait_for_transaction_receipt.return_value = fake_receipt
+
+        from opengradient.types import HistoricalInputQuery, CandleOrder, CandleType
+        query = HistoricalInputQuery("BTC", "USDT", 10, 60, CandleOrder.DESCENDING, [CandleType.CLOSE])
+
+        with patch("opengradient.client.alpha.get_abi", return_value=[]):
+            with patch("opengradient.client.alpha.get_bin", return_value="0x"):
+                with patch("opengradient.client.alpha.run_with_retry", side_effect=lambda fn, *a, **kw: fn()):
+                    with pytest.raises(RuntimeError, match="Contract deployment failed"):
+                        alpha.new_workflow("Qm123", query, "input")
+
+    def test_gas_estimation_failure_logs_warning(self, alpha):
+        """Gas estimation failure must call logger.warning, not print()."""
+        mock_contract = MagicMock()
+        mock_contract.constructor.return_value.estimate_gas.side_effect = Exception("gas error")
+        mock_contract.constructor.return_value.build_transaction.return_value = {}
+
+        fake_receipt = MagicMock()
+        fake_receipt.__getitem__ = lambda self, key: 1 if key == "status" else None
+        fake_receipt.contractAddress = "0xNEW"
+        alpha._blockchain.eth.contract.return_value = mock_contract
+        alpha._blockchain.eth.send_raw_transaction.return_value = b"\xca\xfe"
+        alpha._blockchain.eth.wait_for_transaction_receipt.return_value = fake_receipt
+
+        from opengradient.types import HistoricalInputQuery, CandleOrder, CandleType
+        query = HistoricalInputQuery("BTC", "USDT", 10, 60, CandleOrder.DESCENDING, [CandleType.CLOSE])
+
+        with patch("opengradient.client.alpha.get_abi", return_value=[]):
+            with patch("opengradient.client.alpha.get_bin", return_value="0x"):
+                with patch("opengradient.client.alpha.run_with_retry", side_effect=lambda fn, *a, **kw: fn()):
+                    with patch("opengradient.client.alpha.logger") as mock_logger:
+                        alpha.new_workflow("Qm123", query, "input")
+                        mock_logger.warning.assert_called_once()
+                        assert "Gas estimation failed" in mock_logger.warning.call_args[0][0]
+
+    def test_scheduler_failure_logs_warning(self, alpha):
+        """Scheduler registration failure must call logger.warning, not print()."""
+        alpha._blockchain.eth.contract.return_value.functions.registerTask.return_value.build_transaction.side_effect = Exception("scheduler error")
+        alpha._blockchain.eth.get_transaction_count.return_value = 1
+
+        from opengradient.types import SchedulerParams
+        with patch("opengradient.client.alpha.get_abi", return_value=[]):
+            with patch("opengradient.client.alpha.logger") as mock_logger:
+                alpha._register_with_scheduler("0xCONTRACT", SchedulerParams(frequency=60, duration_hours=1))
+                mock_logger.warning.assert_called_once()
+                assert "scheduler" in mock_logger.warning.call_args[0][0].lower()


### PR DESCRIPTION
## Summary

- **`alpha.py`** — Replace two `print()` calls with `logger.warning()` so gas estimation failures and scheduler registration errors are captured by the caller's logging infrastructure instead of going to stdout
- **`alpha.py`** — Change `raise Exception(...)` to `raise RuntimeError(...)` in `new_workflow` to match the exception type used consistently everywhere else in the codebase; updated docstring to reflect that gas estimation failure uses a fallback instead of raising
- **`alpha.py`** — Fixed `_register_with_scheduler` docstring: previously claimed `Raises: Exception` but the method never raises — errors are caught, logged, and swallowed intentionally since the workflow contract is already deployed
- **`llm.py`** — Strengthen the `choices[]` guard in `_chat_request`: added `isinstance(choices, list)` and `isinstance(choices[0], dict)` checks — the previous `if not choices` guard passes silently for `[None]` or non-list types, which then crashes with an unhelpful `AttributeError`
- **`llm.py` / `types.py`** — Log malformed SSE JSON chunks with `logger.warning()` instead of silently `continue`-ing, making it visible when the server sends broken data during streaming

## Files Changed

- `src/opengradient/client/alpha.py`
- `src/opengradient/client/llm.py`
- `src/opengradient/types.py`
- `tests/client_test.py`

## Test Plan

- [x] Full test suite passes: `uv run pytest tests/ -v` → **121 passed**
- [x] `TestChoicesGuard` — verifies `choices=[]` and `choices=[None]` both raise `RuntimeError`
- [x] `TestSSEJsonLogging` — verifies malformed SSE JSON emits `logger.warning`, valid chunks do not
- [x] `TestAlphaErrorHandling` — verifies deployment failure raises `RuntimeError`, gas estimation failure and scheduler failure both call `logger.warning`
