### PR TITLE
fix: use httpx context manager and align transaction_hash in Twins.chat()

### DIFF
--- a/src/opengradient/client/twins.py
+++ b/src/opengradient/client/twins.py
@@ -70,16 +70,17 @@ class Twins:
             payload["max_tokens"] = max_tokens
 
         try:
-            response = httpx.post(url, json=payload, headers=headers, timeout=60)
-            response.raise_for_status()
-            result = response.json()
+            with httpx.Client() as client:
+                response = client.post(url, json=payload, headers=headers, timeout=60)
+                response.raise_for_status()
+                result = response.json()
 
             choices = result.get("choices")
             if not choices:
                 raise RuntimeError(f"Invalid response: 'choices' missing or empty in {result}")
 
             return TextGenerationOutput(
-                transaction_hash="",
+                transaction_hash="external",
                 finish_reason=choices[0].get("finish_reason"),
                 chat_output=choices[0].get("message"),
                 payment_hash=None,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -5,7 +5,9 @@ import pytest
 
 from opengradient.client.llm import LLM
 from opengradient.client.model_hub import ModelHub
+from opengradient.client.twins import Twins
 from opengradient.types import (
+    TEE_LLM,
     StreamChunk,
     x402SettlementMode,
 )
@@ -190,3 +192,68 @@ class TestX402SettlementMode:
         assert x402SettlementMode.PRIVATE == "private"
         assert x402SettlementMode.BATCH_HASHED == "batch"
         assert x402SettlementMode.INDIVIDUAL_FULL == "individual"
+
+
+# --- Twins Tests ---
+
+
+class TestTwinsChat:
+    """Tests for Twins.chat() resource management and response consistency."""
+
+    @patch("opengradient.client.twins.httpx.Client")
+    def test_chat_uses_context_manager(self, mock_client_cls):
+        """Verify httpx.Client is used as a context manager so connections are closed."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock(post=MagicMock(return_value=mock_response)))
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        twins = Twins(api_key="test-key")
+        result = twins.chat(
+            twin_id="0xabc",
+            model=TEE_LLM.GROK_4,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        mock_client_cls.return_value.__enter__.assert_called_once()
+        mock_client_cls.return_value.__exit__.assert_called_once()
+
+    @patch("opengradient.client.twins.httpx.Client")
+    def test_chat_returns_external_transaction_hash(self, mock_client_cls):
+        """Verify transaction_hash is 'external' for consistency with LLM class."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock(post=MagicMock(return_value=mock_response)))
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        twins = Twins(api_key="test-key")
+        result = twins.chat(
+            twin_id="0xabc",
+            model=TEE_LLM.GROK_4,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert result.transaction_hash == "external"
+
+    @patch("opengradient.client.twins.httpx.Client")
+    def test_chat_empty_choices_raises(self, mock_client_cls):
+        """Verify RuntimeError when choices is empty."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"choices": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock(post=MagicMock(return_value=mock_response)))
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        twins = Twins(api_key="test-key")
+        with pytest.raises(RuntimeError, match="'choices' missing or empty"):
+            twins.chat(
+                twin_id="0xabc",
+                model=TEE_LLM.GROK_4,
+                messages=[{"role": "user", "content": "hello"}],
+            )


### PR DESCRIPTION
## Summary
- `Twins.chat()` called `httpx.post()` directly without a context manager, leaving the underlying TCP connection unclosed after each request. Wrapped the HTTP call in `httpx.Client()` context manager to ensure proper cleanup.
- `transaction_hash` was set to an empty string `""`, while `LLM.completion()` and `LLM.chat()` both use `"external"` for non-blockchain responses. Aligned to `"external"` for consistency across the SDK.
- Added 3 tests covering: context manager usage verification, transaction_hash value assertion, and empty choices error handling.

## Test plan
- [x] `test_chat_uses_context_manager` — verifies `__enter__` and `__exit__` are called
- [x] `test_chat_returns_external_transaction_hash` — asserts `transaction_hash == "external"`
- [x] `test_chat_empty_choices_raises` — confirms `RuntimeError` on empty choices
- [x] All existing tests in `client_test.py` pass
