### PR TITLE
fix: correct misleading log, swallowed exception, and HTTP client leak in RegistryTEEConnection.reconnect()

### DIFF
--- a/src/opengradient/client/tee_connection.py
+++ b/src/opengradient/client/tee_connection.py
@@ -151,12 +151,31 @@ class RegistryTEEConnection:
         )
 
     async def reconnect(self) -> None:
-        """Connect to a new TEE from the registry and rebuild the HTTP client."""
+        """Connect to a new TEE from the registry and rebuild the HTTP client.
+
+        On success, closes the previous HTTP client to free the underlying
+        TCP connection.  On failure, the existing connection is kept and the
+        exception is re-raised so callers can take appropriate action.
+        """
         async with self._refresh_lock:
+            old_active = self._active
             try:
                 self._active = self._connect()
             except Exception:
-                logger.debug("Failed to close previous HTTP client during TEE refresh.", exc_info=True)
+                logger.warning(
+                    "Failed to reconnect to a new TEE from registry; keeping existing connection.",
+                    exc_info=True,
+                )
+                raise
+            else:
+                # Close the old HTTP client now that we have a live replacement.
+                try:
+                    await old_active.http_client.aclose()
+                except Exception:
+                    logger.debug(
+                        "Failed to close previous HTTP client after successful TEE refresh.",
+                        exc_info=True,
+                    )
 
     # ── Background health check ─────────────────────────────────────────
 


### PR DESCRIPTION
## Bug Fix: `RegistryTEEConnection.reconnect()` — misleading log, swallowed exception, resource leak

### Summary

Three bugs found in `RegistryTEEConnection.reconnect()` in `tee_connection.py`:

---

### Bug 1 — Wrong log message

**Before:**
```python
async def reconnect(self) -> None:
    async with self._refresh_lock:
        try:
            self._active = self._connect()
        except Exception:
            logger.debug("Failed to close previous HTTP client during TEE refresh.", exc_info=True)
```

The log message says `"Failed to close previous HTTP client"` — but the code never tried to close anything. The actual failure was in `self._connect()` (registry lookup, TLS handshake, etc.). The error message was completely wrong, making debugging nearly impossible.

---

### Bug 2 — Exception silently swallowed

After `self._connect()` fails, the exception is caught and **discarded**. The caller (including `_tee_refresh_loop`) has no way to know that the reconnect failed. `self._active` stays pointing to the old (potentially dead) TEE and the system appears healthy.

---

### Bug 3 — Resource leak on successful reconnect

When `self._connect()` **succeeds**, the old `ActiveTEE.http_client` is **never closed**. The old `httpx` client and its underlying TCP connection are leaked every time a reconnect happens (every 5 minutes by the background loop).

---

### Fix

```python
async def reconnect(self) -> None:
    async with self._refresh_lock:
        old_active = self._active
        try:
            self._active = self._connect()
        except Exception:
            logger.warning(
                "Failed to reconnect to a new TEE from registry; keeping existing connection.",
                exc_info=True,
            )
            raise  # re-raise so callers know reconnect failed
        else:
            # Close old client only after successful reconnect
            try:
                await old_active.http_client.aclose()
            except Exception:
                logger.debug(
                    "Failed to close previous HTTP client after successful TEE refresh.",
                    exc_info=True,
                )
```

---

### Impact

- Every 5-minute background TEE health check that triggers a reconnect leaks one HTTP connection
- Registry or TLS failures during reconnect are invisible to callers and logs
- Debugging TEE connectivity issues is significantly harder with a misleading log message

---

> @adambalogh @kylexqian — three bugs in one method, all related. Happy to add a unit test if that would help get this merged. 🙏