### PR TITLE
fix: guard json.loads() in JSON tensor parsing — prevent hard crash on None or malformed tensor values

### DIFF
--- a/src/opengradient/client/_conversions.py
+++ b/src/opengradient/client/_conversions.py
@@ -156,7 +156,15 @@ def convert_to_model_output(event_data: AttributeDict) -> Dict[str, np.ndarray]:
             if isinstance(tensor, (AttributeDict, dict)):
                 name = tensor.get("name")
                 value = tensor.get("value")
-                output_dict[name] = np.array(json.loads(value))
+                if name is None:
+                    logging.warning("JSON tensor is missing 'name' field; skipping.")
+                    continue
+                try:
+                    output_dict[name] = np.array(json.loads(value))
+                except (json.JSONDecodeError, TypeError) as e:
+                    logging.warning(
+                        f"Failed to parse JSON tensor '{name}' — value={value!r}: {e}. Skipping."
+                    )
             else:
                 logging.warning(f"Unexpected tensor type: {type(tensor)}")
 
@@ -203,7 +211,15 @@ def convert_array_to_model_output(array_data: List) -> ModelOutput:
     for tensor in array_data[2]:
         name = tensor[0]
         value = tensor[1]
-        json_data[name] = np.array(json.loads(value))
+        if name is None:
+            logging.warning("JSON tensor entry is missing a name; skipping.")
+            continue
+        try:
+            json_data[name] = np.array(json.loads(value))
+        except (json.JSONDecodeError, TypeError) as e:
+            logging.warning(
+                f"Failed to parse JSON tensor '{name}' — value={value!r}: {e}. Skipping."
+            )
 
     return ModelOutput(
         numbers=number_data,


### PR DESCRIPTION
## Bug Fix: Unguarded `json.loads()` crashes entire client when JSON tensor value is `None` or malformed

### Summary

Two unguarded `json.loads()` calls in `_conversions.py` cause a hard crash whenever a JSON tensor's value field is missing or contains invalid JSON. Also found a missing `None` check on tensor names that silently corrupts the output dictionary.

---

### Bug 1 — `convert_to_model_output`: unguarded `json.loads(value)`

```python
# BEFORE (crashes if value is None or malformed JSON)
for tensor in output.get("jsons", []):
    if isinstance(tensor, (AttributeDict, dict)):
        name = tensor.get("name")
        value = tensor.get("value")
        output_dict[name] = np.array(json.loads(value))  # 💥 JSONDecodeError / TypeError
```

If `value` is `None` (field missing from the response) → `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`

If `value` is a malformed JSON string → `json.JSONDecodeError`

Both crash the entire inference call with a traceback that gives no useful context.

---

### Bug 2 — `convert_array_to_model_output`: same unguarded `json.loads(value)`

```python
# BEFORE (same crash in the array-based output path)
for tensor in array_data[2]:
    name = tensor[0]
    value = tensor[1]
    json_data[name] = np.array(json.loads(value))  # 💥 same crash
```

---

### Bug 3 — `None` tensor name silently corrupts output dict

In both functions, if `name` is `None` (missing from the response), the code does:
```python
output_dict[None] = np.array(...)
```
This inserts a `None` key into the output dict without any warning, making it impossible for callers to use the result correctly.

---

### Fix

Wrapped both `json.loads()` calls in `try/except (json.JSONDecodeError, TypeError)` and added a `None` name guard with a `continue` + `logging.warning()` in both functions.

```python
# AFTER
if name is None:
    logging.warning("JSON tensor is missing 'name' field; skipping.")
    continue
try:
    output_dict[name] = np.array(json.loads(value))
except (json.JSONDecodeError, TypeError) as e:
    logging.warning(f"Failed to parse JSON tensor '{name}' — value={value!r}: {e}. Skipping.")
```

---

### Impact

Any model whose output includes a JSON tensor with a missing or malformed value field will crash the entire SDK client mid-inference with no useful error message. This affects both the event-based (`convert_to_model_output`) and array-based (`convert_array_to_model_output`) output paths.

---

> @adambalogh @kylexqian — both output conversion paths had the same unguarded call. Fixed in both places. Happy to add tests if needed. 🙏