### PR TITLE
fix: add missing chainId to inference transaction in _send_tx_with_revert_handling()

### DIFF
--- a/src/opengradient/client/alpha.py
+++ b/src/opengradient/client/alpha.py
@@ -164,6 +164,7 @@ class Alpha:
                 "nonce": nonce,
                 "gas": gas_limit,
                 "gasPrice": self._blockchain.eth.gas_price,
+                "chainId": self._blockchain.eth.chain_id,
             }
         )
 


### PR DESCRIPTION
## Bug Fix: Missing `chainId` in `_send_tx_with_revert_handling()` — affects all `infer()` calls

### Summary

`_send_tx_with_revert_handling()` in `alpha.py` is missing `chainId` when building the inference transaction. Every other transaction in the same file includes it — this method was the only exception.

---

### The Bug

```python
# BEFORE — _send_tx_with_revert_handling (used by infer())
transaction = run_function.build_transaction(
    {
        "from": self._wallet_account.address,
        "nonce": nonce,
        "gas": gas_limit,
        "gasPrice": self._blockchain.eth.gas_price,
        # ❌ chainId missing
    }
)
```

Compare with every other transaction in the same file:

```python
# new_workflow ✅
transaction = contract.constructor(*constructor_args).build_transaction(
    {
        ...
        "chainId": self._blockchain.eth.chain_id,  # ✅ present
    }
)

# run_workflow ✅
transaction = run_function.build_transaction(
    {
        ...
        "chainId": self._blockchain.eth.chain_id,  # ✅ present
    }
)

# _register_with_scheduler ✅
scheduler_tx = scheduler_contract.functions.registerTask(...).build_transaction(
    {
        ...
        "chainId": self._blockchain.eth.chain_id,  # ✅ present
    }
)
```

---

### Impact

- `_send_tx_with_revert_handling` is called by `infer()` — the **primary and most commonly used Alpha Testnet method**
- Without `chainId`, Web3.py signs the transaction without EIP-155 replay protection
- Some RPC nodes reject transactions that lack `chainId`; others silently accept them but the transaction may be replayable on other chains
- This is an inconsistency that makes `infer()` behave differently from every other transaction in `alpha.py`

---

### Fix

```python
# AFTER ✅
transaction = run_function.build_transaction(
    {
        "from": self._wallet_account.address,
        "nonce": nonce,
        "gas": gas_limit,
        "gasPrice": self._blockchain.eth.gas_price,
        "chainId": self._blockchain.eth.chain_id,  # ✅ added
    }
)
```

---

> @adambalogh @kylexqian — one-line fix that makes `infer()` consistent with every other transaction in the same file. 🙏