### PR TITLE
docs: clarify x402 endpoint discovery in SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ alpha = og.Alpha(private_key=os.environ.get("OG_PRIVATE_KEY"))
 hub = og.ModelHub(email="you@example.com", password="...")
 ```
 
+### x402 Endpoint Discovery
+
+By default, `og.LLM(...)` automatically discovers active TEE endpoints from the on-chain TEE registry.
+You do not need to hardcode an LLM endpoint URL:
+
+```python
+llm = og.LLM(private_key=os.environ.get("OG_PRIVATE_KEY"))
+```
+
+For development or self-hosted TEE servers, you can provide a specific endpoint:
+
+```python
+llm = og.LLM.from_url(
+    private_key=os.environ.get("OG_PRIVATE_KEY"),
+    llm_server_url="https://your-tee-endpoint.example.com",
+)
+```
+
+**Note:** x402 payment settlement always happens on **Base Sepolia**, regardless of which TEE endpoint serves the request.
+
 ### OPG Token Approval
 
 Before making LLM requests, your wallet must approve OPG token spending via the [Permit2](https://github.com/Uniswap/permit2) protocol. This only sends an on-chain transaction when the current allowance drops below the threshold:

--- a/examples/README.md
+++ b/examples/README.md
@@ -171,7 +171,7 @@ print(f"Tx hash: {result.transaction_hash}")
 
 ### LLM Chat
 
-LLM chat methods are async:
+LLM chat methods are async. The default client auto-discovers active TEE endpoints from the on-chain registry:
 
 ```python
 llm = og.LLM(private_key=os.environ.get("OG_PRIVATE_KEY"))
@@ -181,6 +181,15 @@ completion = await llm.chat(
     messages=[{"role": "user", "content": "Your message"}],
 )
 print(f"Response: {completion.chat_output['content']}")
+```
+
+For development or self-hosted TEE servers, use a custom endpoint:
+
+```python
+llm = og.LLM.from_url(
+    private_key=os.environ.get("OG_PRIVATE_KEY"),
+    llm_server_url="https://your-tee-server.local",
+)
 ```
 
 ## Finding Model CIDs

--- a/src/opengradient/__init__.py
+++ b/src/opengradient/__init__.py
@@ -23,6 +23,7 @@ See **`opengradient.types`** for shared data types (``TEE_LLM``, ``InferenceMode
 import asyncio
 import opengradient as og
 
+# Auto-discovers active TEE endpoints from the on-chain registry.
 llm = og.LLM(private_key="0x...")
 
 # One-time OPG token approval (idempotent -- skips if allowance is sufficient)
@@ -35,6 +36,12 @@ response = asyncio.run(llm.chat(
     max_tokens=200,
 ))
 print(response.chat_output)
+```
+
+For development or self-hosted TEE servers, you can pin an endpoint:
+
+```python
+llm = og.LLM.from_url(private_key="0x...", llm_server_url="https://localhost:8080")
 ```
 
 ## Streaming


### PR DESCRIPTION
## Summary
- document that `og.LLM(...)` auto-discovers active TEE endpoints from the on-chain TEE registry
- add explicit `LLM.from_url(...)` guidance for development/self-hosted setups
- note that x402 settlement still occurs on Base Sepolia regardless of serving endpoint

## Files Updated
- README.md
- examples/README.md
- src/opengradient/__init__.py

Fixes #229
