### PR TITLE
fix: replace garbled UTF-8 arrow characters in WINDOWS_INSTALL.md

### DIFF
--- a/WINDOWS_INSTALL.md
+++ b/WINDOWS_INSTALL.md
@@ -4,7 +4,7 @@ The `opengradient` package requires a C compiler
 to build its native dependencies. Windows does not
 have one by default.
 
-## Step 1 — Enable WSL
+## Step 1 - Enable WSL
 
 Open PowerShell as Administrator and run:
 
@@ -12,7 +12,7 @@ Open PowerShell as Administrator and run:
 
 Restart your PC when prompted.
 
-## Step 2 — Install Python and uv inside WSL
+## Step 2 - Install Python and uv inside WSL
 
 Open the Ubuntu app and run:
 
@@ -20,17 +20,17 @@ Open the Ubuntu app and run:
     curl -LsSf https://astral.sh/uv/install.sh | sh
     source $HOME/.local/bin/env
 
-## Step 3 — Install SDK
+## Step 3 - Install SDK
 
     uv add opengradient
 
-## Step 4 — Verify
+## Step 4 - Verify
 
     uv run python3 -c "import opengradient; print('Ready!')"
 
 ## Common Errors
 
-- Visual C++ 14.0 required → Use WSL instead
-- wsl: command not found → Update Windows 10 to Build 19041+
-- WSL stuck → Enable Virtualization in BIOS
-- uv: command not found → Run: source $HOME/.local/bin/env
+- Visual C++ 14.0 required -> Use WSL instead
+- wsl: command not found -> Update Windows 10 to Build 19041+
+- WSL stuck -> Enable Virtualization in BIOS
+- uv: command not found -> Run: source $HOME/.local/bin/env


### PR DESCRIPTION
## Bug
WINDOWS_INSTALL.md contains garbled UTF-8 characters in the 
Common Errors section. Arrow characters → were being rendered 
as â†' due to encoding issues, making the Windows installation 
guide unreadable for the users who need it most.

## Fix
Replaced all garbled arrow characters with plain ASCII arrows (->)
and ensured the file is saved with proper UTF-8 encoding throughout.

## Impact
- Windows users following the install guide were seeing corrupted text
- Particularly ironic since this is the Windows-specific guide