### PR TITLE
fix: add _get_model_id() helper to prevent IndexError on missing '/' separator

### DIFF
--- a/src/opengradient/client/llm.py
+++ b/src/opengradient/client/llm.py
@@ -47,6 +47,17 @@ class _ChatParams:
     x402_settlement_mode: x402SettlementMode
 
 
+def _get_model_id(model) -> str:
+    """Extract model ID from provider/model-name format, raising ValueError for invalid formats."""
+    value = model.value if hasattr(model, "value") else str(model)
+    parts = value.split("/", 1)
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid model identifier '{value}'. Expected 'provider/model-name' format."
+        )
+    return parts[1]
+
+
 class LLM:
     """
     LLM inference namespace.
@@ -252,7 +263,7 @@ class LLM:
         Raises:
             RuntimeError: If the inference fails.
         """
-        model_id = model.split("/")[1]
+        model_id = _get_model_id(model)
         payload: Dict = {
             "model": model_id,
             "prompt": prompt,
@@ -327,7 +338,7 @@ class LLM:
             RuntimeError: If the inference fails.
         """
         params = _ChatParams(
-            model=model.split("/")[1],
+            model=_get_model_id(model),
             max_tokens=max_tokens,
             temperature=temperature,
             stop_sequence=stop_sequence,


### PR DESCRIPTION
## Summary

Fixes #249

## Problem

Both `completion()` and `chat()` in `llm.py` were calling `model.split('/')[1]` directly. When a caller passes a model string without a `/` separator, this raises an unhelpful `IndexError: list index out of range`.

## Fix

Added a `_get_model_id()` helper function that:
- Handles both `TEE_LLM` enum instances and plain strings
- Raises a clear `ValueError` with an actionable message if the format is invalid
- Is reused in both `completion()` and `chat()` methods

## Changes

- `src/opengradient/client/llm.py`: Added `_get_model_id()` helper and replaced both raw `.split('/')[1]` calls