### PR TITLE
fix: remove unused json_tensors dead variable in convert_to_model_input()

### DIFF
--- a/src/opengradient/client/_conversions.py
+++ b/src/opengradient/client/_conversions.py
@@ -57,7 +57,6 @@ def convert_to_model_input(inputs: Dict[str, np.ndarray]) -> Tuple[List[Tuple[st
     logging.debug("Converting the following input dictionary to ModelInput: %s", inputs)
     number_tensors = []
     string_tensors = []
-    json_tensors = []
     for tensor_name, tensor_data in inputs.items():
         # Convert to NP array if list or single object
         if isinstance(tensor_data, list):


### PR DESCRIPTION
## Summary

Fixes #250

## Problem

`convert_to_model_input()` in `_conversions.py` initialized `json_tensors = []` but never populated it or included it in the return value. This is dead code that creates a silent data loss trap — if someone adds JSON tensor support to the collection loop in the future without fixing the return statement, JSON inputs will silently disappear.

## Fix

Removed the unused `json_tensors` variable entirely. If JSON tensor support is added in the future, it should be introduced together with the collection logic, return statement update, and caller updates in the same PR.

## Changes

- `src/opengradient/client/_conversions.py`: Removed dead `json_tensors = []` variable