### PR TITLE
fix: close old HTTP client in RegistryTEEConnection.reconnect()

### DIFF
--- a/src/opengradient/client/tee_connection.py
+++ b/src/opengradient/client/tee_connection.py
@@ -153,8 +153,14 @@ class RegistryTEEConnection:
     async def reconnect(self) -> None:
         """Connect to a new TEE from the registry and rebuild the HTTP client."""
         async with self._refresh_lock:
+            old_client = self._active.http_client
             try:
                 self._active = self._connect()
+            except Exception:
+                logger.debug("Failed to reconnect TEE.", exc_info=True)
+                return
+            try:
+                await old_client.aclose()
             except Exception:
                 logger.debug("Failed to close previous HTTP client during TEE refresh.", exc_info=True)
 


### PR DESCRIPTION
## Summary

Fixes #247

## Problem

`RegistryTEEConnection.reconnect()` was replacing `self._active` with a new connection without closing the old HTTP client first. In long-running apps that reconnect frequently (e.g. every 5 minutes), this leaks file descriptors and can eventually exhaust system resources.

## Fix

Applied the same pattern already used in `StaticTEEConnection.reconnect()`:
1. Save the old HTTP client reference before reconnecting
2. Establish the new connection
3. `aclose()` the old client after successful reconnect

## Changes

- `src/opengradient/client/tee_connection.py`: Fixed `RegistryTEEConnection.reconnect()` to close old HTTP client