### PR TITLE
fix: restrict config file permissions to owner-only (0o600)

### DIFF
--- a/src/opengradient/cli.py
+++ b/src/opengradient/cli.py
@@ -34,6 +34,7 @@ def load_og_config():
 def save_og_config(ctx):
     with OG_CONFIG_FILE.open("w") as f:
         json.dump(ctx.obj, f)
+    OG_CONFIG_FILE.chmod(0o600)
 
 
 # Convert string to dictionary click parameter typing


### PR DESCRIPTION
## Problem

When \opengradient config init\ saves the user's Ethereum private key to \~/.opengradient_config.json\, the file is created with default permissions (typically 644), making it readable by all users on the system.

Any process or user on the same machine can read the private key and drain the wallet.

## Fix

Add \OG_CONFIG_FILE.chmod(0o600)\ after writing the config file, restricting access to the file owner only.

## Changes

- **\src/opengradient/cli.py\**: Added \chmod(0o600)\ call in \save_og_config()\ after \json.dump()\

Closes #257