### PR TITLE
fix: use LLM.from_url() when llm_server_url is provided

### DIFF
--- a/src/opengradient/agents/og_langchain.py
+++ b/src/opengradient/agents/og_langchain.py
@@ -177,15 +177,16 @@ class OpenGradientChatModel(BaseChatModel):
         if not private_key:
             raise ValueError("private_key is required when client is not provided.")
 
-        llm_kwargs: Dict[str, Any] = {}
-        if rpc_url is not None:
-            llm_kwargs["rpc_url"] = rpc_url
-        if tee_registry_address is not None:
-            llm_kwargs["tee_registry_address"] = tee_registry_address
         if llm_server_url is not None:
-            llm_kwargs["llm_server_url"] = llm_server_url
+            self._llm = LLM.from_url(private_key, llm_server_url)
+        else:
+            llm_kwargs: Dict[str, Any] = {}
+            if rpc_url is not None:
+                llm_kwargs["rpc_url"] = rpc_url
+            if tee_registry_address is not None:
+                llm_kwargs["tee_registry_address"] = tee_registry_address
 
-        self._llm = LLM(private_key=private_key, **llm_kwargs)
+            self._llm = LLM(private_key=private_key, **llm_kwargs)
         self._owns_client = True
 
     @property


### PR DESCRIPTION
## Problem

\OpenGradientChatModel\ in \og_langchain.py\ passes \llm_server_url\ as a keyword argument to \LLM()\, but \LLM.__init__()\ only accepts \private_key\, \pc_url\, and \	ee_registry_address\.

This causes a \TypeError: __init__() got an unexpected keyword argument 'llm_server_url'\ at runtime when a developer tries to use the \llm_server_url\ parameter through \langchain_adapter()\ or \OpenGradientChatModel()\.

The correct API for creating an LLM client with a hardcoded TEE endpoint is \LLM.from_url(private_key, llm_server_url)\.

## Fix

When \llm_server_url\ is provided, call \LLM.from_url(private_key, llm_server_url)\ instead of passing it as a kwarg to \LLM()\. The regular \LLM()\ constructor path is preserved for the \pc_url\/\	ee_registry_address\ case.

## Changes

- **\src/opengradient/agents/og_langchain.py\**: Branch on \llm_server_url\ to call the correct constructor

Closes #248