### PR TITLE
fix: add missing dependencies and correct badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenGradient Python SDK
 
-[![Checks](https://github.com/OpenGradient/sdk/actions/workflows/test.yml/badge.svg)](https://github.com/OpenGradient/sdk/actions/workflows/test.yml)
-[![E2E Tests](https://github.com/OpenGradient/sdk/actions/workflows/e2e.yml/badge.svg)](https://github.com/OpenGradient/sdk/actions/workflows/e2e.yml)
+[![Checks](https://github.com/OpenGradient/OpenGradient-SDK/actions/workflows/test.yml/badge.svg)](https://github.com/OpenGradient/OpenGradient-SDK/actions/workflows/test.yml)
+[![E2E Tests](https://github.com/OpenGradient/OpenGradient-SDK/actions/workflows/e2e.yml/badge.svg)](https://github.com/OpenGradient/OpenGradient-SDK/actions/workflows/e2e.yml)
 [![PyPI](https://img.shields.io/pypi/v/opengradient)](https://pypi.org/project/opengradient/)
 
 A Python SDK for decentralized model management and inference services on the OpenGradient platform. The SDK provides programmatic access to distributed AI infrastructure with cryptographic verification capabilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
     "langchain>=0.3.7",
     "openai>=1.58.1",
     "pydantic>=2.9.2",
-    "og-x402==0.0.1.dev4"
+    "og-x402==0.0.1.dev4",
+    "requests-toolbelt>=1.0.0",
+    "httpx>=0.27.0"
 ]
 
 [project.optional-dependencies]
@@ -72,7 +74,7 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 140
-target-version = "py310"
+target-version = "py311"
 select = ["E", "F", "I", "N"]
 ignore = []
 

--- a/src/opengradient/cli.py
+++ b/src/opengradient/cli.py
@@ -825,14 +825,6 @@ def generate_image(ctx, model: str, prompt: str, output_path: Path, width: int, 
         click.echo(f'Generating image with model "{model}"')
         raise NotImplementedError("Image generation is not yet supported.")
 
-        # Save the image
-        with open(output_path, "wb") as f:
-            f.write(image_data)
-
-        click.echo()  # Add a newline for better spacing
-        click.secho("✅ Image generation successful", fg="green", bold=True)
-        click.echo(f"Image saved to: {output_path}")
-
     except Exception as e:
         click.echo(f"Error generating image: {str(e)}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,15 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
+
+[options]
+exclude-newer = "2026-04-02T11:21:55.980577Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1867,18 +1871,20 @@ wheels = [
 
 [[package]]
 name = "opengradient"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "eth-account" },
     { name = "firebase-rest-api" },
+    { name = "httpx" },
     { name = "langchain" },
     { name = "numpy" },
     { name = "og-x402" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "requests-toolbelt" },
     { name = "web3" },
 ]
 
@@ -1903,6 +1909,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "eth-account", specifier = ">=0.13.4" },
     { name = "firebase-rest-api", specifier = ">=1.11.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain", specifier = ">=0.3.7" },
     { name = "langgraph", marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -1914,6 +1921,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests-toolbelt", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "types-protobuf", marker = "extra == 'dev'" },
     { name = "web3", specifier = ">=7.3.0" },


### PR DESCRIPTION
## Problem

`pyproject.toml` is missing `requests-toolbelt` and `httpx` as direct dependencies, causing `ImportError` when users install the SDK via pip and use `ModelHub.upload()` or the LLM/twins clients. Additionally, README CI badge URLs point to a non-existent `OpenGradient/sdk` repo.

## Fix

Added the missing dependencies to `pyproject.toml`, corrected the Ruff `target-version` to match `requires-python`, fixed CI badge URLs, and removed unreachable code in `cli.py`.

## Changes

- **`pyproject.toml`** — Added `requests-toolbelt` and `httpx` to `[project.dependencies]`, changed Ruff `target-version` from `"py310"` to `"py311"` to match `requires-python = ">=3.11"`
- **`README.md`** — Fixed CI badge URLs from `OpenGradient/sdk` to `OpenGradient/OpenGradient-SDK`
- **`src/opengradient/cli.py`** — Removed unreachable code after `raise NotImplementedError` in `generate_image`

## Testing

- Verified `requests-toolbelt` and `httpx` are listed in dependencies
- Confirmed badge URLs resolve correctly
- Checked no functional code was removed from cli.py

Closes #265