### PR TITLE
replace legacy gasPrice with EIP-1559 fee fields in Alpha client

### DIFF
--- a/src/opengradient/client/alpha.py
+++ b/src/opengradient/client/alpha.py
@@ -1,5 +1,5 @@
 """
-Alpha Testnet features for OpenGradient SDK.
+Alpha Testnet features for OpenGradient SDK
 
 This module contains features that are only available on the Alpha Testnet,
 including on-chain ONNX model inference, workflow management, and ML model execution.
@@ -163,7 +163,7 @@ class Alpha:
                 "from": self._wallet_account.address,
                 "nonce": nonce,
                 "gas": gas_limit,
-                "gasPrice": self._blockchain.eth.gas_price,
+                "maxFeePerGas": self._blockchain.eth.gas_price, "maxPriorityFeePerGas": self._blockchain.eth.gas_price,
             }
         )
 
@@ -308,7 +308,7 @@ class Alpha:
                     "from": self._wallet_account.address,
                     "nonce": self._blockchain.eth.get_transaction_count(self._wallet_account.address, "pending"),
                     "gas": gas_limit,
-                    "gasPrice": self._blockchain.eth.gas_price,
+                    "maxFeePerGas": self._blockchain.eth.gas_price, "maxPriorityFeePerGas": self._blockchain.eth.gas_price,
                     "chainId": self._blockchain.eth.chain_id,
                 }
             )
@@ -359,7 +359,7 @@ class Alpha:
                 {
                     "from": self._wallet_account.address,
                     "gas": 300000,
-                    "gasPrice": self._blockchain.eth.gas_price,
+                    "maxFeePerGas": self._blockchain.eth.gas_price, "maxPriorityFeePerGas": self._blockchain.eth.gas_price,
                     "nonce": self._blockchain.eth.get_transaction_count(self._wallet_account.address, "pending"),
                     "chainId": self._blockchain.eth.chain_id,
                 }
@@ -425,7 +425,7 @@ class Alpha:
                 "from": self._wallet_account.address,
                 "nonce": nonce,
                 "gas": 30000000,
-                "gasPrice": self._blockchain.eth.gas_price,
+                "maxFeePerGas": self._blockchain.eth.gas_price, "maxPriorityFeePerGas": self._blockchain.eth.gas_price,
                 "chainId": self._blockchain.eth.chain_id,
             }
         )


### PR DESCRIPTION
**Description**

Every transaction sent by the Alpha client uses the legacy gasPrice field
instead of the EIP-1559 fields maxFeePerGas and maxPriorityFeePerGas.

Affected functions in src/opengradient/client/alpha.py:
- _send_tx_with_revert_handling() line 166
- new_workflow() line 311
- _register_with_scheduler() line 362
- run_workflow() line 428

**Why This Is a Problem**

Base Sepolia and the OpenGradient network both use EIP-1559 transaction
pricing. When a transaction is built with gasPrice instead of
maxFeePerGas and maxPriorityFeePerGas, two things can go wrong:

1. On strictly EIP-1559 nodes the transaction is rejected outright and
   the call fails.
2. On nodes that accept both formats, the legacy format causes users
   to overpay on gas because the fee estimation is less efficient.

This means all on-chain operations in the Alpha client including model
inference, workflow deployment, scheduler registration, and workflow
execution are all affected.

**Fix**

Replace gasPrice with the two EIP-1559 fields in all four transaction builders:

"maxFeePerGas": self._blockchain.eth.gas_price,
"maxPriorityFeePerGas": self._blockchain.eth.gas_price,

**Files Changed**

- src/opengradient/client/alpha.py: updated all four transaction
  builders to use EIP-1559 fee fields