### PR TITLE
make Twins.chat() async to prevent event loop blocking

### DIFF
--- a/src/opengradient/client/twins.py
+++ b/src/opengradient/client/twins.py
@@ -18,7 +18,7 @@ class Twins:
 
     Usage:
         twins = og.Twins(api_key="your-api-key")
-        response = twins.chat(
+        response = await twins.chat(
             twin_id="0x1abd463fd6244be4a1dc0f69e0b70cd5",
             model=og.TEE_LLM.GROK_4_1_FAST_NON_REASONING,
             messages=[{"role": "user", "content": "What do you think about AI?"}],
@@ -30,7 +30,7 @@ class Twins:
     def __init__(self, api_key: str):
         self._api_key = api_key
 
-    def chat(
+    async def chat(
         self,
         twin_id: str,
         model: TEE_LLM,
@@ -70,7 +70,8 @@ class Twins:
             payload["max_tokens"] = max_tokens
 
         try:
-            response = httpx.post(url, json=payload, headers=headers, timeout=60)
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, json=payload, headers=headers, timeout=60)
             response.raise_for_status()
             result = response.json()
 


### PR DESCRIPTION
**Description**

Twins.chat() is a synchronous function that uses a blocking httpx.post()
call with a 60 second timeout.

LLM.chat() in the same SDK is correctly defined as async. Twins.chat()
is not, which creates a serious problem when both are used together in
any async application such as FastAPI, LangChain agents, or any asyncio
based service.

When Twins.chat() is called from inside an async context, the blocking
httpx.post() call freezes the entire event loop for up to 60 seconds.
During that time no other async task in the application can run. Other
requests, background jobs, and inference calls all stall completely.

For a chat API that handles many concurrent users this is a full
availability failure.

**Fix**

Two changes to src/opengradient/client/twins.py:

1. Changed def chat() to async def chat() so it works correctly
   inside async applications.

2. Replaced the blocking httpx.post() call with a non-blocking
   httpx.AsyncClient used as an async context manager so the event
   loop is never blocked.

The behavior and return value are identical. Only the execution model
changed from blocking to non-blocking.

**Files Changed**

- src/opengradient/client/twins.py: converted chat() to async and
  replaced httpx.post() with httpx.AsyncClient