### PR TITLE
fix: use async ensure_opg_approval in llm_chat example

### DIFF
--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -10,12 +10,10 @@ logging.getLogger("opengradient").setLevel(logging.DEBUG)
 
 async def main():
     llm = og.LLM(private_key=os.environ.get("OG_PRIVATE_KEY"))
-    llm.ensure_opg_approval(min_allowance=0.1)
-
+    await llm.ensure_opg_approval_async(min_allowance=0.1)
     messages = [
         {"role": "user", "content": "What is the capital of France?"},
     ]
-
     result = await llm.chat(
         model=og.TEE_LLM.GEMINI_2_5_FLASH,
         messages=messages,


### PR DESCRIPTION
The example file llm_chat.py demonstrates usage of ensure_opg_approval() inside an async function without using await.

async def main():
    llm = og.LLM(private_key=...)
    llm.ensure_opg_approval(min_allowance=0.1)  # synchronous call
    result = await llm.chat(...)

This is problematic because:

ensure_opg_approval() is a synchronous, blocking function
It internally performs polling using time.sleep()
When called inside async def, it blocks the entire asyncio event loop

**Impact**

Any developer copying this official example will unknowingly introduce:

Frozen event loop execution
Blocked async tasks and background operations
Delayed or broken network I/O
Inability to handle timeouts or cancellations properly

This leads to incorrect async usage patterns being propagated via official documentation.

**Root Cause**

The example uses a synchronous function inside an async context:

llm.ensure_opg_approval(min_allowance=0.1)

Since this function blocks (via time.sleep() internally), it prevents the event loop from scheduling other coroutines.

**Fix**

Update the example to use the newly introduced async-safe method:

async def main():
    llm = og.LLM(private_key=os.environ.get("OG_PRIVATE_KEY"))
    await llm.ensure_opg_approval_async(min_allowance=0.1)
    result = await llm.chat(...)

**Why this works**
ensure_opg_approval_async() uses asyncio.sleep()
This allows the event loop to continue running other tasks
Ensures the example is correctly aligned with asyncio best practices