### PR TITLE
fix(deps): add missing requests-toolbelt dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-
 dependencies = [
     "eth-account>=0.13.4",
     "web3>=7.3.0",
@@ -24,6 +23,7 @@ dependencies = [
     "firebase-rest-api>=1.11.0",
     "numpy>=1.26.4",
     "requests>=2.32.3",
+    "requests-toolbelt>=0.9.1",
     "langchain>=0.3.7",
     "openai>=1.58.1",
     "pydantic>=2.9.2",


### PR DESCRIPTION
## Problem

`requests-toolbelt` is imported at the top level of
`src/opengradient/client/model_hub.py`:

    from requests_toolbelt import MultipartEncoder

This file is imported by `client/__init__.py`, which is imported by
`opengradient/__init__.py`. This means the very first line of any
user code:

    import opengradient as og

crashes immediately on a clean install with:

    ImportError: No module named 'requests_toolbelt'

`requests-toolbelt` is not listed anywhere in the `dependencies`
section of `pyproject.toml`. So `pip install opengradient` does not
install it. The entire SDK is broken for any user who installs it in
a fresh environment.

Affected files:
- `src/opengradient/client/model_hub.py` (line 9)
- `pyproject.toml` (dependencies section)

## Fix

Added `requests-toolbelt>=0.9.1` to the `dependencies` list in
`pyproject.toml`. This ensures it is installed automatically whenever
a user runs `pip install opengradient`.

No code changes needed. The import in `model_hub.py` is correct.
Only the dependency declaration was missing.

## Changes

- `pyproject.toml`: added `"requests-toolbelt>=0.9.1"` to the
  `dependencies` list under `[project]`