### PR TITLE
docs: add Quick Summary for Developers section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 A Python SDK for decentralized model management and inference services on the OpenGradient platform. The SDK provides programmatic access to distributed AI infrastructure with cryptographic verification capabilities.
 
+## Quick Summary for Developers
+
+> **New to OpenGradient?** Start here.
+
+| Question | Answer |
+|---|---|
+| **What is it?** | A decentralized network that runs AI inference inside TEEs and settles every request on-chain |
+| **What problem does it solve?** | Centralized AI is a black box. OpenGradient gives cryptographic proof for every inference |
+| **How do I use it?** | Install the SDK, get a private key, call llm.chat() like OpenAI but with transaction_hash and tee_signature in every response |
+| **What is Model Hub?** | A decentralized registry to upload, discover, and run custom ONNX models on-chain |
+| **What is MemSync?** | A long-term memory layer for AI agents with persistent context across sessions |
+
+---
+
 ## Overview
 
 OpenGradient enables developers to build AI applications with verifiable execution guarantees through Trusted Execution Environments (TEE) and blockchain-based settlement. The SDK supports standard LLM inference patterns while adding cryptographic attestation for applications requiring auditability and tamper-proof AI execution.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ A Python SDK for decentralized model management and inference services on the Op
 | **What is Model Hub?** | A decentralized registry to upload, discover, and run custom ONNX models on-chain |
 | **What is MemSync?** | A long-term memory layer for AI agents with persistent context across sessions |
 
+### 30-Second Quickstart
+
+Install, grab a private key from the [faucet](https://faucet.opengradient.ai), and run:
+
+    import asyncio, os, opengradient as og
+
+    async def main():
+        llm = og.LLM(private_key=os.environ["OG_PRIVATE_KEY"])
+        llm.ensure_opg_approval(min_allowance=0.1)
+        result = await llm.chat(
+            model=og.TEE_LLM.GEMINI_2_5_FLASH,
+            messages=[{"role": "user", "content": "Hello!"}],
+        )
+        print(result.chat_output["content"])  # AI response
+        print(result.transaction_hash)         # on-chain proof
+
+    asyncio.run(main())
+
 ---
 
 ## Overview


### PR DESCRIPTION
Closes #253

## Summary

Adds a Quick Summary for Developers section to the README directly before the detailed Overview section, as requested in issue #253.

## Changes

- Developer-oriented summary table answering the 5 most common onboarding questions (what it is, what problem it solves, how to use it, Model Hub, MemSync)
- 30-second quickstart code example showing a complete chat call with transaction_hash output
- Placed before the dense architecture Overview so new developers see the simple version first

## Why

The existing Overview explains architecture well but is dense for newcomers. This section lets a new developer understand and run their first inference in under a minute.