### PR TITLE
Close old HTTP client on registry reconnect

### DIFF
--- a/fix(tee): close old HTTP client after registry reconnect
+++ b/fix(tee): close old HTTP client after registry reconnect
@@ -1,0 +1,14 @@
+## Summary
+
+Fixes a connection leak in `RegistryTEEConnection.reconnect()`.
+
+The reconnect path was creating a new active TEE connection without closing the old HTTP client. In long-running processes that refresh or fail over repeatedly, this can leave stale clients open and slowly leak resources.
+
+Fixes #247
+
+## Problem
+
+`RegistryTEEConnection.reconnect()` previously did this:
+
+```python
+self._active = self._connect()


### PR DESCRIPTION
Fixes a connection leak in RegistryTEEConnection.reconnect() by closing the old HTTP client before establishing a new connection, preventing resource leaks in long-running processes.