### PR TITLE
Add ByteDance Seed models to TEE_LLM enum

### DIFF
--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -556,6 +556,11 @@ class TEE_LLM(str, Enum):
     GROK_4_20_NON_REASONING = "x-ai/grok-4.20-non-reasoning"
     GROK_CODE_FAST_1 = "x-ai/grok-code-fast-1"
 
+    # ByteDance Seed models via TEE (BytePlus ModelArk)
+    SEED_1_6 = "bytedance/seed-1.6"
+    SEED_1_8 = "bytedance/seed-1.8"
+    SEED_2_0_LITE = "bytedance/seed-2.0-lite"
+
 
 @dataclass
 class ResponseFormat:


### PR DESCRIPTION
## Summary
Added support for ByteDance Seed models via TEE (BytePlus ModelArk) to the `TEE_LLM` enum in the types module.

## Key Changes
- Added three new ByteDance Seed model variants to the `TEE_LLM` enum:
  - `SEED_1_6` - bytedance/seed-1.6
  - `SEED_1_8` - bytedance/seed-1.8
  - `SEED_2_0_LITE` - bytedance/seed-2.0-lite

## Details
These models are accessed through BytePlus ModelArk and expand the available LLM options for TEE (Trusted Execution Environment) deployments.