### PR TITLE
Add Gemini 3.5 Flash and update Gemini 3.x model listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,10 @@ The SDK provides access to models from multiple providers via the `og.TEE_LLM` e
 - Gemini 2.5 Flash
 - Gemini 2.5 Pro
 - Gemini 2.5 Flash Lite
-- Gemini 3 Pro
 - Gemini 3 Flash
+- Gemini 3.1 Pro
+- Gemini 3.1 Flash Lite
+- Gemini 3.5 Flash
 
 #### xAI
 - Grok 4

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -549,6 +549,7 @@ class TEE_LLM(str, Enum):
     GEMINI_3_FLASH = "google/gemini-3-flash-preview"
     GEMINI_3_1_PRO_PREVIEW = "google/gemini-3.1-pro-preview"
     GEMINI_3_1_FLASH_LITE_PREVIEW = "google/gemini-3.1-flash-lite-preview"
+    GEMINI_3_5_FLASH = "google/gemini-3.5-flash"
 
     # xAI Grok models via TEE
     GROK_4 = "x-ai/grok-4"


### PR DESCRIPTION
## Summary
Updates the supported Google Gemini models in the SDK to reflect the latest model releases and deprecations. Adds support for Gemini 3.5 Flash and updates the model documentation.

## Changes
- **Added Gemini 3.5 Flash** (`google/gemini-3.5-flash`) to the `TEE_LLM` enum in `src/opengradient/types.py`
- **Updated README.md** model listings:
  - Removed deprecated "Gemini 3 Pro" entry
  - Reordered Gemini 3.x models for clarity
  - Added "Gemini 3.1 Pro" and "Gemini 3.1 Flash Lite" entries
  - Added new "Gemini 3.5 Flash" entry

## Implementation Details
The new Gemini 3.5 Flash model is now available for use via the `og.TEE_LLM.GEMINI_3_5_FLASH` enum value, enabling end-to-end verified inference with this latest model variant.

https://claude.ai/code/session_01RbjM9MaFPXaSggFMZaoGPL