### PR TITLE
Add Nous Research Hermes 4 models to TEE_LLM enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ The SDK provides access to models from multiple providers via the `og.TEE_LLM` e
 - Grok 4 Fast
 - Grok 4.1 Fast (reasoning and non-reasoning)
 
+#### Nous Research
+- Hermes 4 405B
+- Hermes 4 70B
+
 For a complete list, reference the `og.TEE_LLM` enum or consult the [API documentation](https://docs.opengradient.ai/api_reference/python_sdk/).
 
 ## Alpha Testnet Features

--- a/docs/opengradient/types.md
+++ b/docs/opengradient/types.md
@@ -509,6 +509,8 @@ auditability and tamper-proof AI inference.
 * static `GROK_4_20_REASONING`
 * static `GROK_4_FAST`
 * static `GROK_CODE_FAST_1`
+* static `HERMES_4_405B`
+* static `HERMES_4_70B`
 * static `O3`
 * static `O4_MINI`
 * static `SEED_1_6`

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -598,6 +598,10 @@ class TEE_LLM(str, Enum):
     SEED_1_8 = "bytedance/seed-1.8"
     SEED_2_0_LITE = "bytedance/seed-2.0-lite"
 
+    # Nous Research Hermes models via TEE (Nous Portal)
+    HERMES_4_405B = "nous/hermes-4-405b"
+    HERMES_4_70B = "nous/hermes-4-70b"
+
 
 @dataclass
 class ResponseFormat:


### PR DESCRIPTION
## Summary
Add support for Nous Research Hermes 4 models (405B and 70B variants) to the SDK's TEE LLM provider list, enabling users to access these models via the Nous Portal.

## Changes
- Added `HERMES_4_405B` and `HERMES_4_70B` enum values to `TEE_LLM` class in `src/opengradient/types.py`
- Updated README.md to document the new Nous Research models under a dedicated section
- Updated auto-generated documentation in `docs/opengradient/types.md` to reflect the new enum values

## Implementation Details
- Models are accessible via the `nous/` namespace: `nous/hermes-4-405b` and `nous/hermes-4-70b`
- Follows the existing pattern for other TEE LLM providers (Grok, ByteDance, etc.)
- Documentation updates maintain consistency with existing provider sections

https://claude.ai/code/session_014CMNvbEaRmSXmZf6d9Sfm7