### PR TITLE
Add DeepSeek V4 models to TEE LLM enum

### DIFF
--- a/docs/opengradient/types.md
+++ b/docs/opengradient/types.md
@@ -483,6 +483,8 @@ auditability and tamper-proof AI inference.
 * static `CLAUDE_OPUS_4_8`
 * static `CLAUDE_SONNET_4_5`
 * static `CLAUDE_SONNET_4_6`
+* static `DEEPSEEK_V4_FLASH`
+* static `DEEPSEEK_V4_PRO`
 * static `GEMINI_2_5_FLASH`
 * static `GEMINI_2_5_FLASH_IMAGE`
 * static `GEMINI_2_5_FLASH_LITE`

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -598,6 +598,10 @@ class TEE_LLM(str, Enum):
     SEED_1_8 = "bytedance/seed-1.8"
     SEED_2_0_LITE = "bytedance/seed-2.0-lite"
 
+    # DeepSeek models via TEE (served through BytePlus ModelArk)
+    DEEPSEEK_V4_FLASH = "bytedance/deepseek-v4-flash"
+    DEEPSEEK_V4_PRO = "bytedance/deepseek-v4-pro"
+
     # Nous Research Hermes models via TEE (Nous Portal)
     HERMES_4_405B = "nous/hermes-4-405b"
     HERMES_4_70B = "nous/hermes-4-70b"


### PR DESCRIPTION
## Summary
Add support for DeepSeek V4 models (Flash and Pro variants) served through BytePlus ModelArk in the TEE LLM inference mode.

## Changes
- Added two new DeepSeek V4 model constants to `TEE_LLM` enum in `src/opengradient/types.py`:
  - `DEEPSEEK_V4_FLASH = "bytedance/deepseek-v4-flash"`
  - `DEEPSEEK_V4_PRO = "bytedance/deepseek-v4-pro"`
- Updated `docs/opengradient/types.md` to document the new model constants

## Details
The DeepSeek V4 models are served through BytePlus ModelArk (Bytedance's infrastructure), consistent with other Bytedance-served models like SEED. These models are now available for end-to-end verified AI inference via the TEE mode.

https://claude.ai/code/session_01Y4REtNaefr2VdrkunjPhQA