### PR TITLE
Add GPT Image 2 model support for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ The SDK provides access to models from multiple providers via the `og.TEE_LLM` e
 - GPT-5
 - GPT-5 Mini
 - GPT-5.2
+- GPT Image 2 (native image generation)
 
 #### Anthropic
 - Claude Sonnet 4.5

--- a/examples/llm_image_generation.py
+++ b/examples/llm_image_generation.py
@@ -34,6 +34,8 @@ async def main():
     # of the signed output hash.
     #
     # Available image generation models:
+    #   OpenAI (flat per-image rate, $0.05/image):
+    #     og.TEE_LLM.GPT_IMAGE_2
     #   Google (inline, billed per output token):
     #     og.TEE_LLM.GEMINI_2_5_FLASH_IMAGE
     #     og.TEE_LLM.GEMINI_3_1_FLASH_IMAGE

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -557,6 +557,12 @@ class TEE_LLM(str, Enum):
     GPT_5_4_NANO = "openai/gpt-5.4-nano"
     GPT_5_5 = "openai/gpt-5.5"
 
+    # OpenAI image-generation model via TEE (dedicated /images/generations
+    # endpoint). Billed at a flat rate per image. Images are returned on
+    # ``TextGenerationOutput.images`` and ``StreamChunk.images`` as data: URIs
+    # and are not part of the signed output hash.
+    GPT_IMAGE_2 = "openai/gpt-image-2"
+
     # Anthropic models via TEE
     CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4-5"
     CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4-6"


### PR DESCRIPTION
## Summary
Add support for OpenAI's GPT Image 2 model via the TEE endpoint for native image generation capabilities.

## Changes
- **`src/opengradient/types.py`**: Added `GPT_IMAGE_2 = "openai/gpt-image-2"` enum value to `TEE_LLM` with documentation noting:
  - Dedicated `/images/generations` endpoint
  - Flat per-image billing rate
  - Images returned as data: URIs in `TextGenerationOutput.images` and `StreamChunk.images`
  - Images not included in signed output hash

- **`examples/llm_image_generation.py`**: Updated example documentation to list GPT Image 2 as an available image generation model with pricing ($0.05/image)

- **`README.md`**: Added "GPT Image 2 (native image generation)" to the OpenAI models list in the supported models section

## Implementation Details
The model follows the existing TEE LLM pattern and integrates with the image generation infrastructure already in place. Images are handled separately from the signed output, consistent with other image generation models like Gemini variants.

https://claude.ai/code/session_01BUq85aJiPfVTWsMCPmWJ1L